### PR TITLE
Enable slider across all screen widths

### DIFF
--- a/assets/css/overrides.css
+++ b/assets/css/overrides.css
@@ -214,35 +214,33 @@ body.is-article-visible #NFT.nft-fixed.active .nft-overlay{ opacity:.25; }
   text-shadow: 0 2px 6px rgba(0,0,0,0.7);
 }
 
-@media (max-width:736px){
-  .wii-slider{
-    display:flex;
-    overflow-x:auto;
-    scroll-snap-type:x mandatory;
-    gap:1rem;
-    padding:1rem;
-    height:65vh;
-    background:rgba(0,0,0,0.35);
-    backdrop-filter:blur(8px);
-    -webkit-backdrop-filter:blur(8px);
-    border-radius:12px;
-    box-shadow:0 8px 32px rgba(0,0,0,0.35);
-    scrollbar-width:none;
-  }
-  .wii-slider::-webkit-scrollbar{ display:none; }
-  .wii-card{
-    flex:0 0 85%;
-    scroll-snap-align:start;
-    border-radius:12px;
-    padding:1rem;
-    height:100%;
-    overflow-y:auto;
-    background:rgba(0,0,0,0.45);
-    backdrop-filter:blur(10px);
-    -webkit-backdrop-filter:blur(10px);
-    border:1px solid rgba(255,255,255,0.15);
-    box-shadow:0 4px 24px rgba(0,0,0,0.3);
-  }
+.wii-slider{
+  display:flex;
+  overflow-x:auto;
+  scroll-snap-type:x mandatory;
+  gap:1rem;
+  padding:1rem;
+  height:65vh;
+  background:rgba(0,0,0,0.35);
+  backdrop-filter:blur(8px);
+  -webkit-backdrop-filter:blur(8px);
+  border-radius:12px;
+  box-shadow:0 8px 32px rgba(0,0,0,0.35);
+  scrollbar-width:none;
+}
+.wii-slider::-webkit-scrollbar{ display:none; }
+.wii-card{
+  flex:0 0 85%;
+  scroll-snap-align:start;
+  border-radius:12px;
+  padding:1rem;
+  height:100%;
+  overflow-y:auto;
+  background:rgba(0,0,0,0.45);
+  backdrop-filter:blur(10px);
+  -webkit-backdrop-filter:blur(10px);
+  border:1px solid rgba(255,255,255,0.15);
+  box-shadow:0 4px 24px rgba(0,0,0,0.3);
 }
 
 /* بک‌گراند کلی صفحه درباره ایران */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -451,8 +451,6 @@
 
   /* ===== What is Iran Coin slider ===== */
   (function(){
-        const mq = window.matchMedia('(max-width:736px)');
-        if (!mq.matches) return;
         const slider = document.querySelector('#What-is-iran-coin .wii-slider');
         if (!slider) return;
         const cards = slider.querySelectorAll('.wii-card');


### PR DESCRIPTION
## Summary
- Run "What is Iran Coin" slider at any screen width
- Apply wii-slider and wii-card styles globally instead of only on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a28977355483208b45077a178e7993